### PR TITLE
Fix light/dark mode toggle

### DIFF
--- a/src/components/JsonDataViewer.svelte
+++ b/src/components/JsonDataViewer.svelte
@@ -1,37 +1,61 @@
 <script>
-  import { onMount } from 'svelte'
-  import { JsonView } from '@zerodevx/svelte-json-view'
+  import { onMount } from "svelte";
+  import { JsonView } from "@zerodevx/svelte-json-view";
 
-  export let data
-  let dark = false
+  export let data;
+  let dark = false;
 
-  let fieldset = []
+  let fieldset = [];
   for (let key in data) {
-    if (key.startsWith('_')) continue
+    if (key.startsWith("_")) continue;
     fieldset.push({
       name: key,
-      value: data[key]
-    })
+      value: data[key],
+    });
   }
 
   onMount(() => {
-    if (
-      localStorage.getItem('color-theme') === 'light' ||
-      (!('color-theme' in localStorage) &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches)
-    ) {
-      dark = false
+    let mode = localStorage.theme;
+    if (!mode)
+      mode = window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    if (mode === "dark") {
+      dark = true;
     } else {
-      dark = true
+      dark = false;
     }
-  })
+  });
 </script>
+
+<table class="table-fixed w-full dark:text-white">
+  <tbody>
+    {#each fieldset as field}
+      <tr>
+        <td
+          class="w-[7rem] md:w-[11rem] px-4 py-1 text-sm text-gray-400 whitespace-nowrap dark:text-gray-400 align-top"
+        >
+          {field.name}
+        </td>
+        <td
+          class="px-4 py-1 text-sm text-gray-600 dark:text-gray-100 align-top value break-words"
+        >
+          {#if Array.isArray(field.value) && field.value.length}
+            <JsonView json={field.value} />
+          {:else}
+            <code>{JSON.stringify(field.value)}</code>
+          {/if}
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>
 
 <style>
   :global(.value .val),
   :global(.value .key) {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-      'Courier New', monospace;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
     font-size: 1em;
   }
 
@@ -59,24 +83,3 @@
     color: #9ca3b0;
   }
 </style>
-
-<table class="table-fixed w-full dark:text-white">
-  <tbody>
-    {#each fieldset as field}
-    <tr>
-      <td
-        class="w-[7rem] md:w-[11rem] px-4 py-1 text-sm text-gray-400 whitespace-nowrap dark:text-gray-400 align-top"
-      >
-        {field.name}
-      </td>
-      <td class="px-4 py-1 text-sm text-gray-600 dark:text-gray-100 align-top value break-words">
-        {#if Array.isArray(field.value) && field.value.length}
-        <JsonView json="{field.value}" />
-        {:else}
-        <code>{JSON.stringify(field.value)}</code>
-        {/if}
-      </td>
-    </tr>
-    {/each}
-  </tbody>
-</table>

--- a/src/components/ToggleModeButton.svelte
+++ b/src/components/ToggleModeButton.svelte
@@ -1,29 +1,20 @@
 <script>
-  import { onMount } from 'svelte'
-  import SquareButton from './SquareButton.svelte'
+  import { onMount } from "svelte";
+  import SquareButton from "./SquareButton.svelte";
 
-  let dark = false
+  let dark = false;
   function toggleDarkMode() {
-    let mode = localStorage.theme || 'light'
-    if (mode === 'dark' || window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      dark = false
-      document.documentElement.classList.remove('dark')
-      localStorage.theme = 'light'
+    let mode = localStorage.theme || "light";
+    if (mode === "dark") {
+      dark = false;
+      document.documentElement.classList.remove("dark");
+      localStorage.theme = "light";
     } else {
-      dark = true
-      document.documentElement.classList.add('dark')
-      localStorage.theme = 'dark'
+      dark = true;
+      document.documentElement.classList.add("dark");
+      localStorage.theme = "dark";
     }
   }
-
-  onMount(() => {
-    let mode = localStorage.theme || 'light'
-    if (mode === 'dark' || window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      dark = true
-    } else {
-      dark = false
-    }
-  })
 </script>
 
 <SquareButton on:click={toggleDarkMode} aria-label="Toggle Dark Mode">
@@ -37,7 +28,9 @@
     focusable="false"
     role="img"
   >
-    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+    <path
+      d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
+    />
   </svg>
   <svg
     class="w-5 h-5"
@@ -50,6 +43,6 @@
       d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
       fill-rule="evenodd"
       clip-rule="evenodd"
-    ></path>
+    />
   </svg>
 </SquareButton>

--- a/src/pages/+layout.svelte
+++ b/src/pages/+layout.svelte
@@ -1,17 +1,21 @@
 <script>
-  import '~/app.css'
+  import "~/app.css";
 </script>
 
 <svelte:head>
   <script>
     if (document) {
-      let mode = localStorage.theme || 'light'
-      if (mode === 'dark' || window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark')
-        localStorage.theme = 'dark'
+      let mode = localStorage.theme;
+      if (!mode)
+        mode = window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+      if (mode === "dark") {
+        document.documentElement.classList.add("dark");
+        localStorage.theme = "dark";
       } else {
-        document.documentElement.classList.remove('dark')
-        localStorage.theme = 'light'
+        document.documentElement.classList.remove("dark");
+        localStorage.theme = "light";
       }
     }
   </script>


### PR DESCRIPTION
The color toggle wasn't working for me on Firefox. It would work once when changing from dark mode to light mode, but stopped working after that. Also, upon refresh it would reset to dark mode regardless.

This has been fixed in this pull request, primarily in the `src/pages/+layout.svelte` file.