### PR TITLE
Patch 2024.12.1

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -41,7 +41,7 @@ jobs:
       - name: Build /docs
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
   deploy:
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -810,9 +810,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001546",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz",
-      "integrity": "sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "dev": true,
       "funding": [
         {
@@ -2760,9 +2760,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001546",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz",
-      "integrity": "sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "dev": true
     },
     "chokidar": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,9 +239,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001317:
-  version "1.0.30001546"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz"
-  integrity sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==
+  version "1.0.30001690"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz"
+  integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
 
 chokidar@^3.5.3:
   version "3.5.3"


### PR DESCRIPTION
The main workflow has been updated to avoid its failure in the near future.

Email from Github:

> Artifact actions v3 will be closing down by January 30, 2025. You are receiving this email because you have GitHub Actions workflows using v3 of [actions/upload-artifact](https://app.github.media/e/er?s=88570519&lid=6648&elqTrackId=867ac6c9fa524bda9764f13bec8f8014&elq=d4cd42fd53944a77877c405d1624827b&elqaid=4286&elqat=1&elqak=8AF5D94B629B77D0B2E640E5D18BB16F17951D6DC3F7FFD2530526E38AB4D8C51DFB) or [actions/download-artifact](https://app.github.media/e/er?s=88570519&lid=6647&elqTrackId=bb54934dfd8c4c44b0e64ec2f2ba4824&elq=d4cd42fd53944a77877c405d1624827b&elqaid=4286&elqat=1&elqak=8AF57B355AADDDE608896B61A68B985ADA841D6DC3F7FFD2530526E38AB4D8C51DFB). After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.
> 
> To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
> - January 9th, 12pm - 1pm EST
> - January 16th, 10am-2pm EST
> - January 23rd, 9am-5pm EST
>
> What you need to do
> Update workflows to begin using v4 of the artifact actions as soon as possible. While v4 improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://app.github.media/e/er?s=88570519&lid=6646&elqTrackId=e5ab3eaa455c4e8baa6af6be9fdb5c62&elq=d4cd42fd53944a77877c405d1624827b&elqaid=4286&elqat=1&elqak=8AF58F0002C617A8A55C9135F66B959381051D6DC3F7FFD2530526E38AB4D8C51DFB) from previous versions that may require updates to your workflows. Please see [the documentation](https://app.github.media/e/er?s=88570519&lid=6645&elqTrackId=af6fe6939f7e4dcba105e35734b7e6a0&elq=d4cd42fd53944a77877c405d1624827b&elqaid=4286&elqat=1&elqak=8AF5780CABD5F82033875E5CE3EF4DF2FDFC1D6DC3F7FFD2530526E38AB4D8C51DFB) in the project repositories for guidance on how to migrate your workflows.