### PR TITLE
Patch 2025.12.2

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -25,5 +25,12 @@
       "sizes": "512x512",
       "purpose": "maskable"
     }
-  ]
+  ],
+  "share_target": {
+    "action": "/",
+    "method": "GET",
+    "params": {
+      "text": "q"
+    }
+  }
 }


### PR DESCRIPTION
This update should allow search queries to be sent to the iptv-org app from other installed apps (such as GitHub).

Details: https://developer.chrome.com/docs/capabilities/web-apis/web-share-target